### PR TITLE
Check if dig output has MX record

### DIFF
--- a/EmailChecker.php
+++ b/EmailChecker.php
@@ -102,6 +102,11 @@ class EmailChecker
 
         foreach ($lines as $line) {
             $mxInfo = explode(' ', preg_replace('!\s+!', ' ', $line));
+
+            if ($mxInfo[3] != 'MX'){
+                continue;
+            }
+
             $output[] = [
                 'host' => $mxInfo[0],
                 'ttl' => $mxInfo[1],


### PR DESCRIPTION
Check if dig output has MX record

sometimes dig query for MX returns result with CNAME.
It also raises undefined array index error.

Add additional check for that.

@hostinger/devs
issue https://github.com/hostinger/disposable-emails/issues/21